### PR TITLE
Revert "Fix: ignore the "two many transfer encodings" error in golang http package"

### DIFF
--- a/common/httpc.go
+++ b/common/httpc.go
@@ -147,11 +147,7 @@ func GetRespAsPlaintext(url string) (string, error) {
 func GetRespAsJSONType(url string, jsonType interface{}) error {
 	resp, err := http.Get(url)
 	if err != nil {
-		if strings.Contains(err.Error(), "too many transfer encodings") {
-			fmt.Printf("Warning: found that response headers contain more than one 'transfer-encodings'\n")
-		} else {
-			return newHTTPError(err.Error(), 0)
-		}
+		return newHTTPError(err.Error(), 0)
 	}
 	defer resp.Body.Close()
 
@@ -208,12 +204,8 @@ func HTTPRequest(url, method string, auth Authenticate, needResult bool, dataPay
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		if strings.Contains(err.Error(), "too many transfer encodings") {
-			fmt.Printf("Warning: found that response headers contain more than one 'transfer-encodings'\n")
-		} else {
-			fmt.Println(err)
-			return respText, StatusUnknown, false
-		}
+		fmt.Println(err)
+		return respText, StatusUnknown, false
 	}
 
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION


  Seems this does not help the error as it will cause response body
  empty problem