### PR TITLE
Add flag clearCache for uploaded files

### DIFF
--- a/Jenkinsfile.it
+++ b/Jenkinsfile.it
@@ -97,7 +97,7 @@ pipeline {
     stage("Run test") {
       steps {
         sh 'chmod +x ./build/indy-test'
-        sh "./build/indy-test integrationtest ${INDY_URL} ${DATASET_REPO_URL} ${BUILD_ID} ${PROMOTE_TARGET} ${META_CHECK_REPO} --dryRun=${DRY_RUN}"
+        sh "./build/indy-test integrationtest ${INDY_URL} ${DATASET_REPO_URL} ${BUILD_ID} ${PROMOTE_TARGET} ${META_CHECK_REPO} --clearCache=${CLEAR_CACHE} --dryRun=${DRY_RUN}"
       }
     }
 

--- a/cmd/integrationtest/command.go
+++ b/cmd/integrationtest/command.go
@@ -35,15 +35,17 @@ func NewIntegrationTestCmd() *cobra.Command {
 				cmd.Help()
 				os.Exit(1)
 			}
+			clearCache, _ := cmd.Flags().GetBool("clearCache")
 			dryRun, _ := cmd.Flags().GetBool("dryRun")
 			metaCheckRepo := ""
 			if len(args) >= 5 {
 				metaCheckRepo = args[4]
 			}
-			integrationtest.Run(args[0], args[1], args[2], args[3], metaCheckRepo, dryRun)
+			integrationtest.Run(args[0], args[1], args[2], args[3], metaCheckRepo, clearCache, dryRun)
 		},
 	}
 
+	exec.Flags().BoolP("clearCache", "c", false, "Clear cached built artifact files. This will force download from original again.")
 	exec.Flags().BoolP("dryRun", "d", false, "Print msg for repo creation, down/upload, promote, and clean up, without really doing it.")
 
 	return exec

--- a/pkg/integrationtest/run.go
+++ b/pkg/integrationtest/run.go
@@ -56,7 +56,7 @@ const (
  * j. Retrieve the metadata files from step #f again, check if the new version is gone
  * k. Delete the temp group and the hosted repo A. Delete folo record.
  */
-func Run(indyBaseUrl, datasetRepoUrl, buildId, promoteTargetStore, metaCheckRepo string, dryRun bool) {
+func Run(indyBaseUrl, datasetRepoUrl, buildId, promoteTargetStore, metaCheckRepo string, clearCache, dryRun bool) {
 	//a. Clone dataset repo
 	datasetRepoDir := cloneRepo(datasetRepoUrl)
 	fmt.Printf("Clone SUCCESS, dir: %s\n", datasetRepoDir)
@@ -78,8 +78,9 @@ func Run(indyBaseUrl, datasetRepoUrl, buildId, promoteTargetStore, metaCheckRepo
 	foloFileLoc := path.Join(datasetRepoDir, buildId, dataset.TRACKING_JSON)
 	foloTrackContent := common.GetFoloRecordFromFile(foloFileLoc)
 	originalIndy := getOriginalIndyBaseUrl(foloTrackContent.Uploads[0].LocalUrl)
+
 	prev := t
-	buildName := buildtest.DoRun(originalIndy, "", indyBaseUrl, packageType, foloTrackContent, 1, dryRun)
+	buildName := buildtest.DoRun(originalIndy, "", indyBaseUrl, packageType, foloTrackContent, 1, clearCache, dryRun)
 	t = time.Now()
 	fmt.Printf("Create mock group(%s) and download/upload SUCCESS, elapsed(s): %f\n", buildName, t.Sub(prev).Seconds())
 


### PR DESCRIPTION
The test cache the uploaded artifact files on the PV. But sometimes we need to clean corrupt files. The the flag to clean up.