### PR TITLE
Reset the timeout for the job

### DIFF
--- a/Jenkinsfile.it
+++ b/Jenkinsfile.it
@@ -66,12 +66,8 @@ pipeline {
       """
     }
   }
-  // TODO let's enable this after the test
-  //triggers {
-    //cron('@midnight')
-  //}
   options {
-    timeout(time: 360, unit: 'MINUTES')
+    timeout(time: 1, unit: 'HOURS')
   }
   environment {
     PIPELINE_NAMESPACE = readFile('/run/secrets/kubernetes.io/serviceaccount/namespace').trim()


### PR DESCRIPTION
I found some of jobs stuck due to some reason and hang close for 360 mins, we should reset it to 1 hour at most. 