### PR TITLE
Alter npm upload path for .tgz

### DIFF
--- a/pkg/buildtest/run.go
+++ b/pkg/buildtest/run.go
@@ -218,10 +218,10 @@ func prepareUploadEntriesByFolo(originalIndyURL, targetIndyURL, newBuildId strin
 func createUploadUrls(originalIndy, targetIndy, newBuildId string, up common.TrackedContentEntry) (string, string) {
 	storePath := common.StoreKeyToPath(up.StoreKey) // original store, e.g, maven/hosted/build-1234
 	uploadPath := path.Join("api/content", storePath, up.Path)
-	orgiUpUrl := fmt.Sprintf("%s%s", originalIndy, uploadPath)                                 // original url to retrieve artifact
-	alteredUploadPath := common.AlterUploadPath(up.Path, newBuildId[len(common.BUILD_TEST_):]) // replace version number
-	toks := strings.Split(storePath, "/")                                                      // get package/type, e.g., maven/hosted
-	targetStorePath := path.Join(toks[0], toks[1], newBuildId, alteredUploadPath)              // e.g, maven/hosted/build-913413/org/...
+	orgiUpUrl := fmt.Sprintf("%s%s", originalIndy, uploadPath)                                              // original url to retrieve artifact
+	alteredUploadPath := common.AlterUploadPath(up.Path, up.StoreKey, newBuildId[len(common.BUILD_TEST_):]) // replace version number
+	toks := strings.Split(storePath, "/")                                                                   // get package/type, e.g., maven/hosted
+	targetStorePath := path.Join(toks[0], toks[1], newBuildId, alteredUploadPath)                           // e.g, maven/hosted/build-913413/org/...
 	targUpUrl := fmt.Sprintf("%sapi/folo/track/%s/%s", targetIndy, newBuildId, targetStorePath)
 	return orgiUpUrl, targUpUrl
 }

--- a/pkg/buildtest/run_test.go
+++ b/pkg/buildtest/run_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAlterUploadPath(t *testing.T) {
 	rawPath := "/org/apache/kafka/connect-api/2.7.0.redhat-00012/connect-api-2.7.0.redhat-00012-javadoc.jar"
-	altered := common.AlterUploadPath(rawPath, "999999")
+	altered := common.AlterUploadPath(rawPath, "maven:hosted:build-123", "999999")
 	expected := "/org/apache/kafka/connect-api/2.7.0.redhat-999999/connect-api-2.7.0.redhat-999999-javadoc.jar"
 	Convey("Replacing should work", t, func() {
 		So(altered, ShouldEqual, expected)

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -16,7 +16,9 @@
 
 package common
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestIsRegularFile(t *testing.T) {
 	type args struct {
@@ -40,6 +42,39 @@ func TestIsRegularFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsRegularFile(tt.args.fileLoc); got != tt.want {
 				t.Errorf("IsRegularFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlterUploadPath(t *testing.T) {
+	type args struct {
+		rawPath          string
+		storeKey         string
+		newReleaseNumber string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+		{name: "maven", args: args{
+			rawPath:          "/org/apache/kafka/connect-api/2.7.0.redhat-00012/connect-api-2.7.0.redhat-00012-javadoc.jar",
+			storeKey:         "maven:hosted:build-101385",
+			newReleaseNumber: "94465"},
+			want: "/org/apache/kafka/connect-api/2.7.0.redhat-94465/connect-api-2.7.0.redhat-94465-javadoc.jar"},
+		{name: "npm1", args: args{
+			rawPath: "/@redhat/opossum/-/opossum-6.2.1.tgz", storeKey: "npm:hosted:build-AMRM", newReleaseNumber: "94465"},
+			want: "/@redhat/opossum/-/opossum-6.2.1-94465.tgz"},
+		{name: "npm2", args: args{
+			rawPath: "/@redhat/kogito-tooling-backend/-/kogito-tooling-backend-0.9.0-3.tgz", storeKey: "npm:hosted:build-ALNI", newReleaseNumber: "94465"},
+			want: "/@redhat/kogito-tooling-backend/-/kogito-tooling-backend-0.9.0-94465.tgz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AlterUploadPath(tt.args.rawPath, tt.args.storeKey, tt.args.newReleaseNumber); got != tt.want {
+				t.Errorf("AlterUploadPath() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/integrationtest/run.go
+++ b/pkg/integrationtest/run.go
@@ -182,7 +182,7 @@ func verifyFoloRecord(indyBaseUrl, buildName string, originalTrackContent common
 	return true
 }
 
-func checkFoloEntries(title string, alterPath func(string, string) string, buildName string,
+func checkFoloEntries(title string, alterPath func(string, string, string) string, buildName string,
 	entries, originalEntries []common.TrackedContentEntry) []string {
 
 	logger.Infof("Verify folo records - %s", title)
@@ -196,7 +196,7 @@ func checkFoloEntries(title string, alterPath func(string, string) string, build
 	for _, v := range originalEntries {
 		p := v.Path
 		if alterPath != nil {
-			p = alterPath(v.Path, buildName[len(common.BUILD_TEST_):])
+			p = alterPath(v.Path, v.StoreKey, buildName[len(common.BUILD_TEST_):])
 		}
 		// Not check metadata. e.g, when downloading a metadata through a group, folo will ingore it.
 		if common.IsRegularFile(p) {

--- a/pkg/promotetest/run.go
+++ b/pkg/promotetest/run.go
@@ -32,14 +32,14 @@ func DoRun(indyBaseUrl, foloTrackId, sourceStore, targetStore, newVersionNum str
 	}
 
 	for _, up := range foloTrackContent.Uploads {
-		if common.IsMetadata(up.Path) {
+		if common.IsMetadata(up.Path, up.StoreKey) {
 			continue // ignore matedata
 		}
 		if newVersionNum == "" {
 			paths = append(paths, up.Path)
 		} else {
 			// replace version with newVersionNum, e.g, xxx-redhat-### to xxx-redhat-<newVersion>
-			altered := common.AlterUploadPath(up.Path, newVersionNum)
+			altered := common.AlterUploadPath(up.Path, up.StoreKey, newVersionNum)
 			paths = append(paths, altered)
 		}
 	}


### PR DESCRIPTION
NPM have different path patterns with maven. We have to alter the raw path accordingly.