### PR TITLE
Fix the format time

### DIFF
--- a/pkg/common/httpc.go
+++ b/pkg/common/httpc.go
@@ -87,7 +87,7 @@ const (
 	MethodOptions = http.MethodOptions
 )
 
-const DATA_TIME = "2006-01-02 15:04:02"
+const DATA_TIME = "2006-01-02 15:04:05"
 
 const NotStoreFile = ""
 


### PR DESCRIPTION
I found the logs always show 18 in sec position, based on the doc, this should be `2006-01-02 15:04:05`