### PR TITLE
Leave the warning log only

### DIFF
--- a/pkg/common/httpc.go
+++ b/pkg/common/httpc.go
@@ -368,7 +368,11 @@ func download(targetUrl, storeFileName string, proxyConfig *ProxyConfig) bool {
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
 			fmt.Printf("Warning: cannot download file due to io error! error is %s\n", err.Error())
-			//return false
+			// TODO it reports this for chunked response, but after investigation, the file can be downloaded
+			// even though this error, let's ignore this for the timebeing
+			if !strings.Contains(err.Error(), "tls: user canceled") {
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/common/httpc.go
+++ b/pkg/common/httpc.go
@@ -368,7 +368,7 @@ func download(targetUrl, storeFileName string, proxyConfig *ProxyConfig) bool {
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
 			fmt.Printf("Warning: cannot download file due to io error! error is %s\n", err.Error())
-			return false
+			//return false
 		}
 	}
 	return true


### PR DESCRIPTION
After checking and verify the downloaded files, looks it's fine even though the following error reported, I think it's good to leave the warning message only and figure out a better way later. 
```
    File can be download ✔[2022-04-12 16:03:25] Downloading (By Proxy) https://registry.npmjs.org/set-blocking
Create http client with proxy http://test-build-123+tracking:pass@localhost:8082
Warning: cannot download file due to io error! error is remote error: tls: user canceled
```